### PR TITLE
Use Poppins instead of Comfortaa; streamlined font-family

### DIFF
--- a/ALL TEMPLATES/Footer/style.css
+++ b/ALL TEMPLATES/Footer/style.css
@@ -1,5 +1,4 @@
 body {
-  font-family: Arial, sans-serif;
   margin: 0;
   /* box-sizing: border-box; */
 }

--- a/ALL TEMPLATES/Login page/style.css
+++ b/ALL TEMPLATES/Login page/style.css
@@ -1,7 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
-
 .body1 {
-    font-family: 'Comfortaa', Arial, sans-serif;
     background-color: #f0f0f0; /* Light background */
     margin: 0;
     padding: 0;
@@ -57,7 +54,6 @@
 }
 
 .inputtxt {
-    font-family: "Comfortaa", sans-serif;
     margin-bottom: 1rem;
     padding: 0.5rem;
     border: 2px solid;

--- a/ALL TEMPLATES/Navbar/AfterNav.css
+++ b/ALL TEMPLATES/Navbar/AfterNav.css
@@ -8,7 +8,6 @@
 *{
     padding: 0;
     margin: 0;
-    font-family: "Comfortaa", sans-serif;
     box-sizing: border-box;
 }
 .a{

--- a/ALL TEMPLATES/User-upload/style.css
+++ b/ALL TEMPLATES/User-upload/style.css
@@ -7,7 +7,6 @@
 * {
     padding: 0;
     margin: 0;
-    font-family: "Comfortaa", sans-serif;
     box-sizing: border-box;
 }
 

--- a/ALL TEMPLATES/about/about.css
+++ b/ALL TEMPLATES/about/about.css
@@ -1,6 +1,5 @@
 /* Basic styling for the body */
 body {
-    font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
     background-color: #f4f4f4;

--- a/ALL TEMPLATES/registration page/1.css
+++ b/ALL TEMPLATES/registration page/1.css
@@ -9,7 +9,6 @@
     --box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .body1 {
-    font-family: 'Comfortaa', Arial, sans-serif;
     background-color: black;
     margin: 0;
     padding: 0;
@@ -46,7 +45,7 @@
 }
 
 .login-input {
-    font-family: 'Comfortaa', sans-serif;
+    /* font-family: 'Comfortaa', sans-serif; */
     margin-bottom: 1rem;
     padding: 0.75rem;
     border: none;
@@ -67,7 +66,7 @@
     border-radius: 4px;
     cursor: pointer;
     transition: background-color 0.3s;
-    font-family: 'Comfortaa', sans-serif;
+    /* font-family: 'Comfortaa', sans-serif; */
     font-weight: bold;
 }
 

--- a/ALL TEMPLATES/service_page/service.css
+++ b/ALL TEMPLATES/service_page/service.css
@@ -1,12 +1,10 @@
 /* General styling for the page */
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap'); 
+
 *{
     padding: 0;
     margin: 0;
-    font-family: comfortaa;
 }
 .body {
-    font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
     background-color: #f0f0f0;

--- a/Landing page/style.css
+++ b/Landing page/style.css
@@ -6,7 +6,6 @@
 }
 
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: #f5f7fa;
     color: #333333;
     line-height: 1.6;

--- a/backend/templates/change_password.html
+++ b/backend/templates/change_password.html
@@ -9,7 +9,6 @@
         margin: 0;
         padding: 0;
         background-color: #f0f0f0;
-        font-family: Arial, sans-serif;
       }
       .email-wrapper {
         width: 100%;

--- a/backend/templates/change_password_template.html
+++ b/backend/templates/change_password_template.html
@@ -7,10 +7,7 @@
     <title>Walkez Login</title>
 
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
-
         .body1 {
-            font-family: 'Comfortaa', Arial, sans-serif;
             background-color: #f0f0f0;
             margin: 0;
             padding: 0;

--- a/backend/templates/email_already_verified.html
+++ b/backend/templates/email_already_verified.html
@@ -8,7 +8,6 @@
         body {
             background-color: white;
             color: black;
-            font-family: Arial, sans-serif;
             display: flex;
             flex-direction: column;
             align-items: center;

--- a/backend/templates/email_template.html
+++ b/backend/templates/email_template.html
@@ -9,7 +9,6 @@
         margin: 0;
         padding: 0;
         background-color: #f0f0f0;
-        font-family: Arial, sans-serif;
       }
       .email-wrapper {
         width: 100%;

--- a/backend/templates/email_verification_failed.html
+++ b/backend/templates/email_verification_failed.html
@@ -6,7 +6,6 @@
     <title>Email Verification Failed</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
             background-color: #f8d7da;
             color: #721c24;
             text-align: center;

--- a/backend/templates/email_verification_success.html
+++ b/backend/templates/email_verification_success.html
@@ -6,7 +6,6 @@
     <title>Email Verification Success</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
             background-color: #f4f4f4;
             margin: 0;
             padding: 0;

--- a/frontend/src/CSS/User_Css/Login.css
+++ b/frontend/src/CSS/User_Css/Login.css
@@ -1,6 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
 .body1 {
-    font-family: 'Comfortaa', Arial, sans-serif;
     background-color: #f0f0f0; /* Light background */
     margin: 0;
     padding: 0;
@@ -28,7 +26,7 @@
     color: #000000;
     margin-bottom: 1.5rem;
     text-align: center;
-    font-family: "Comfortaa", sans-serif;
+    /* font-family: "Comfortaa", sans-serif; */
 }
 .login {
     color:  #000000;
@@ -42,7 +40,7 @@
 }
 
 .inputtxt {
-    font-family: "Comfortaa", sans-serif;
+    /* font-family: "Comfortaa", sans-serif; */
     margin-bottom: 1rem;
     padding: 0.5rem;
     border: 1px solid;

--- a/frontend/src/CSS/User_Css/Nav.css
+++ b/frontend/src/CSS/User_Css/Nav.css
@@ -7,7 +7,6 @@
 * {
     padding: 0;
     margin: 0;
-    font-family: "Comfortaa", sans-serif;
     box-sizing: border-box;
 }
 
@@ -127,7 +126,7 @@
 a {
     text-decoration: none;
     color: var(--white);
-    font-family: 'Courier New', Courier, monospace;
+    /* font-family: 'Courier New', Courier, monospace; */
 }
 
 .company_logo {

--- a/frontend/src/CSS/User_Css/Register.css
+++ b/frontend/src/CSS/User_Css/Register.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap');
-
 :root{
     --primary-color: #007bff;
     --secondary-color: #6c757d;
@@ -9,7 +7,6 @@
     --box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .body1 {
-    font-family: 'Comfortaa', Arial, sans-serif;
     background-color: #f0f0f0; /* Light background */
     margin: 0;
     padding: 0;
@@ -46,7 +43,7 @@
 }
 
 .login-input {
-    font-family: 'Comfortaa', sans-serif;
+    /* font-family: 'Comfortaa', sans-serif; */
     margin-bottom: 1rem;
     padding: 0.75rem;
     border: 1px solid;
@@ -67,7 +64,7 @@
     border-radius: 4px;
     cursor: pointer;
     transition: background-color 0.3s;
-    font-family: 'Comfortaa', sans-serif;
+    /* font-family: 'Comfortaa', sans-serif; */
     font-weight: bold;
 }
 

--- a/frontend/src/CSS/User_Css/service.css
+++ b/frontend/src/CSS/User_Css/service.css
@@ -1,9 +1,6 @@
-/* General styling for the page */
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&display=swap'); 
 *{
     padding: 0;
     margin: 0;
-    font-family: comfortaa;
     /* overflow-x: hidden; */
 }
 .body {
@@ -12,7 +9,6 @@
     /* align-items: center; */
     /* justify-content: center; */
     /* flex-direction: column; */
-    font-family: Arial, sans-serif;
     /* margin: 0; */
     padding: 0;
     background-color: #f0f0f0;
@@ -29,7 +25,7 @@
     /* align-items: center; */
     /* justify-content: center; */
     /* flex-direction: column; */
-    font-family: Arial, sans-serif;
+    /* font-family: Arial, sans-serif; */
     /* margin: 0; */
     padding: 0;
     background-color: #f0f0f0;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["Poppins", "sans-serif"],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Earlier, almost every css file has imported the font family again and again, leading to redundancy. I've streamlined everything into the single tailwind config file, and the font family is imported directly on the root css file, making it easy to switch/add families (if ever needed)