### PR TITLE
 🔗Fix: Update Footer Copyright Year is now Dynamic

### DIFF
--- a/frontend/src/Pages/User_Pages/Components/Footer.jsx
+++ b/frontend/src/Pages/User_Pages/Components/Footer.jsx
@@ -2,6 +2,7 @@ import "../../../CSS/User_Css/Footer.css";
 import React from "react";
 
 const Footer = () => {
+  const currentYear = new Date().getFullYear();
   return (
     <footer >
       <div className="footer-container">
@@ -59,7 +60,7 @@ const Footer = () => {
       </div>
 
       <div className="footer-copy">
-        <p>&copy; 2024 Walk-ez. All rights reserved</p>
+       <p>&copy; {currentYear} Walk-ez. All rights reserved</p><p>&copy; {currentYear} Walk-ez. All rights reserved</p>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Description
The copyright year displayed in the footer is now dynamic 

## fix  #105
## screenshot 
![image](https://github.com/user-attachments/assets/bcdc4102-f2b0-4edd-906a-2a3844204804)

